### PR TITLE
Fix add_to_slack_spec missing ok: true in OAuth mock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Change Log
 
+* 2026/04/20: Raise a descriptive error when Slack OAuth returns `ok: false`, or when an Enterprise Grid install is attempted - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * [#93](https://github.com/dblock/slack-gamebot2/pull/93): Added `set elo algorithm glicko|glicko2` and `set elo glicko2 tau` — Glicko-1 and Glicko-2 rating algorithms - [@dblock](https://github.com/dblock).
 * [#92](https://github.com/dblock/slack-gamebot2/pull/92): Added `set elo algorithm adaptive|standard`, `set elo k` and `set elo decay` — algorithm can only be changed at the start of a new season - [@dblock](https://github.com/dblock).
 * [#91](https://github.com/dblock/slack-gamebot2/pull/91): Added rolling 10-game elo average (`avg`) to rank and leaderboard output - [@dblock](https://github.com/dblock).

--- a/lib/api/endpoints/teams_endpoint.rb
+++ b/lib/api/endpoints/teams_endpoint.rb
@@ -53,6 +53,9 @@ module SlackGamebot
 
             rc = client.send(SlackRubyBotServer.config.oauth_access_method, options)
 
+            raise rc['error'] || 'invalid OAuth response' unless rc['ok']
+            raise 'Enterprise Grid is not supported.' if rc['ok'] && rc['team'].nil?
+
             token = nil
             access_token = nil
             user_id = nil

--- a/spec/api/endpoints/teams_endpoint_spec.rb
+++ b/spec/api/endpoints/teams_endpoint_spec.rb
@@ -93,6 +93,7 @@ describe SlackGamebot::Api::Endpoints::TeamsEndpoint do
     context 'register' do
       before do
         oauth_access = {
+          'ok' => true,
           'access_token' => 'token',
           'token_type' => 'bot',
           'bot_user_id' => 'bot_user_id',
@@ -185,6 +186,55 @@ describe SlackGamebot::Api::Endpoints::TeamsEndpoint do
           expect(team.bot_user_id).to eq 'bot_user_id'
           expect(team.activated_user_id).to eq 'activated_user_id'
         end.not_to change(Team, :count)
+      end
+
+      context 'when oauth returns an error' do
+        before do
+          allow_any_instance_of(Slack::Web::Client).to receive(:oauth_v2_access).and_return(
+            'ok' => false,
+            'error' => 'invalid_code'
+          )
+        end
+
+        it 'raises the error' do
+          expect { client.teams._post(code: 'bad_code') }.to raise_error Faraday::ClientError do |e|
+            json = JSON.parse(e.response[:body])
+            expect(json['message']).to eq 'invalid_code'
+          end
+        end
+      end
+
+      context 'when oauth returns ok: false without an error message' do
+        before do
+          allow_any_instance_of(Slack::Web::Client).to receive(:oauth_v2_access).and_return(
+            'ok' => false
+          )
+        end
+
+        it 'raises an invalid OAuth response error' do
+          expect { client.teams._post(code: 'bad_code') }.to raise_error Faraday::ClientError do |e|
+            json = JSON.parse(e.response[:body])
+            expect(json['message']).to eq 'invalid OAuth response'
+          end
+        end
+      end
+
+      context 'when oauth returns an enterprise grid response without a team' do
+        before do
+          allow_any_instance_of(Slack::Web::Client).to receive(:oauth_v2_access).and_return(
+            'ok' => true,
+            'access_token' => 'xoxb-enterprise',
+            'team' => nil,
+            'enterprise' => { 'id' => 'E123', 'name' => 'My Enterprise' }
+          )
+        end
+
+        it 'raises an enterprise not supported error' do
+          expect { client.teams._post(code: 'code') }.to raise_error Faraday::ClientError do |e|
+            json = JSON.parse(e.response[:body])
+            expect(json['message']).to eq 'Enterprise Grid is not supported.'
+          end
+        end
       end
     end
   end

--- a/spec/integration/add_to_slack_spec.rb
+++ b/spec/integration/add_to_slack_spec.rb
@@ -17,6 +17,7 @@ describe 'Add to Slack', :js, type: :feature do
     allow_any_instance_of(Team).to receive(:ping!).and_return(ok: true)
     expect(SlackRubyBotServer::Service.instance).to receive(:start!)
     oauth_access = {
+      'ok' => true,
       'access_token' => 'token',
       'token_type' => 'bot',
       'bot_user_id' => 'bot_user_id',


### PR DESCRIPTION
The `oauth_access` mock in `spec/integration/add_to_slack_spec.rb` was missing `'ok' => true`, causing the endpoint to raise `'invalid OAuth response'` at the `unless rc['ok']` check in `teams_endpoint.rb:56`.