### PR TITLE
Fix: NoMethodError when channel commands are invoked in a DM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Change Log
 
+* 2026/04/25: Fix: `NoMethodError: undefined method 'team' for nil` when channel commands (e.g. `seasons`) are invoked in a DM - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/04/20: Raise a descriptive error when Slack OAuth returns `ok: false`, or when an Enterprise Grid install is attempted - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * [#93](https://github.com/dblock/slack-gamebot2/pull/93): Added `set elo algorithm glicko|glicko2` and `set elo glicko2 tau` — Glicko-1 and Glicko-2 rating algorithms - [@dblock](https://github.com/dblock).
 * [#92](https://github.com/dblock/slack-gamebot2/pull/92): Added `set elo algorithm adaptive|standard`, `set elo k` and `set elo decay` — algorithm can only be changed at the start of a new season - [@dblock](https://github.com/dblock).

--- a/lib/commands/mixins/channel.rb
+++ b/lib/commands/mixins/channel.rb
@@ -12,6 +12,8 @@ module SlackGamebot
           def channel_command(*values, &_block)
             subscribe_command(*values) do |data|
               channel = data.team.find_create_or_update_channel_by_channel_id!(data.channel, data.user)
+              next unless channel
+
               with_rescue(channel, nil, data) do |channel, _user, data|
                 yield channel, data
               end

--- a/spec/commands/seasons_spec.rb
+++ b/spec/commands/seasons_spec.rb
@@ -71,6 +71,30 @@ describe SlackGamebot::Commands::Seasons do
     end
   end
 
+  context 'dm channel' do
+    include_context 'subscribed team'
+
+    it 'ignores seasons in a DM' do
+      allow(Team).to receive(:where).with(team_id: team.team_id).and_return([team])
+      allow(team.slack_client).to receive(:chat_postMessage)
+      expect do
+        SlackRubyBotServer::Events.config.run_callbacks(
+          :event,
+          %w[event_callback app_mention],
+          Slack::Messages::Message.new(
+            'team_id' => team.team_id,
+            'event' => {
+              'user' => 'user_id',
+              'channel' => 'D0AUHTSA763',
+              'text' => '@gamebot seasons'
+            }
+          )
+        )
+      end.not_to raise_error
+      expect(team.slack_client).not_to have_received(:chat_postMessage)
+    end
+  end
+
   context 'subscribed team' do
     let!(:team) { Fabricate(:team, subscribed: true) }
 


### PR DESCRIPTION
## Problem

When a user invokes a channel-scoped command (like `seasons`) in a DM with the bot, the following error occurs:

```
NoMethodError: undefined method 'team' for nil
  lib/commands/seasons.rb:9
```


## Fix

Added `next unless channel` in `lib/commands/mixins/channel.rb` to silently skip DM events. This is consistent with how DM channels are handled elsewhere (e.g., `dm_command` and `user_in_channel_or_dm_command` both check the `'D'` prefix explicitly).

## Test

Added a regression test in `spec/commands/seasons_spec.rb` that sends `@gamebot seasons` to a DM channel (`D0AUHTSA763`, matching the production incident) and asserts no exception is raised and no message is posted.