### PR TITLE
Return an error when a player tries to register someone else

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Change Log
 
+* 2026/05/03: Return an error when a player tries to register someone else - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/04/26: Reorganized help text: merged General and DMs into Other (at end), moved seasons to Stats, removed duplicates - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/04/25: Send a welcome DM to the user who installed the bot when a team is activated - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/04/25: Added `channels` command (works in DM and channel) listing all enabled channels with current season stats — match count, player count and season count - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).

--- a/lib/commands/register.rb
+++ b/lib/commands/register.rb
@@ -6,20 +6,25 @@ module SlackGamebot
       include SlackGamebot::Commands::Mixins::User
 
       user_in_channel_command 'register' do |channel, user, data|
-        ts = Time.now.utc - 1
-        user.register! if user && !user.registered?
-        user.promote! if user && channel.captains.none?
-        message = if user.created_at >= ts
-                    "Welcome <@#{data.user}>! You're ready to play."
-                  elsif user.updated_at >= ts
-                    "Welcome back <@#{data.user}>, I've updated your registration."
-                  else
-                    "Welcome back <@#{data.user}>, you're already registered."
-                  end
-        message += " You're also team captain." if user.captain?
-        channel.slack_client.say(channel: data.channel, text: message, gif: 'welcome')
-        logger.info "REGISTER: #{channel} - #{data.user}"
-        user
+        if data.match['expression']
+          channel.slack_client.say(channel: data.channel, text: 'Players must register themselves.', gif: 'sorry')
+          logger.info "REGISTER: #{channel} - #{data.user}, failed, cannot register others"
+        else
+          ts = Time.now.utc - 1
+          user.register! if user && !user.registered?
+          user.promote! if user && channel.captains.none?
+          message = if user.created_at >= ts
+                      "Welcome <@#{data.user}>! You're ready to play."
+                    elsif user.updated_at >= ts
+                      "Welcome back <@#{data.user}>, I've updated your registration."
+                    else
+                      "Welcome back <@#{data.user}>, you're already registered."
+                    end
+          message += " You're also team captain." if user.captain?
+          channel.slack_client.say(channel: data.channel, text: message, gif: 'welcome')
+          logger.info "REGISTER: #{channel} - #{data.user}"
+          user
+        end
       end
     end
   end

--- a/spec/commands/register_spec.rb
+++ b/spec/commands/register_spec.rb
@@ -20,6 +20,11 @@ describe SlackGamebot::Commands::Register do
     )
   end
 
+  it 'returns an error when trying to register someone else' do
+    user = Fabricate(:user, registered: true, captain: true, updated_at: 2.days.ago, created_at: 2.days.ago, user_name: 'user_name', user_id: 'user_id')
+    expect(message: '@gamebot register <@someone>', channel: channel, user: user).to respond_with_slack_message('Players must register themselves.')
+  end
+
   it 'registers a new user and promotes them to captain' do
     Fabricate(:user, team: team2, channel: channel2) # another user in another team
     allow_any_instance_of(User).to receive(:channel).and_return(channel)


### PR DESCRIPTION
Fixes #21

When a player runs `register <@someone>`, the bot now responds with "Players must register themselves." instead of silently treating it as a self-registration.
