### PR TITLE
Throttle past due subscription notifications to once every 72 hours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Change Log
 
+* 2026/05/03: Throttle past due subscription notifications to at most once every 72 hours - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/05/03: Return an error when a player tries to register someone else - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/04/26: Reorganized help text: merged General and DMs into Other (at end), moved seasons to Stats, removed duplicates - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/04/25: Send a welcome DM to the user who installed the bot when a team is activated - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).

--- a/lib/app.rb
+++ b/lib/app.rb
@@ -76,12 +76,15 @@ module SlackGamebot
             logger.info "Checking #{team} subscription to #{subscription_name}, #{subscription.status}."
             case subscription.status
             when 'past_due'
+              next if team.past_due_informed_at && Time.now.utc < team.past_due_informed_at + 72.hours
+
               logger.warn "Subscription for #{team} is #{subscription.status}, notifying."
               team.inform! "Your subscription to #{subscription_name} is past due. #{team.update_cc_text}"
+              team.update_attributes!(past_due_informed_at: Time.now.utc)
             when 'canceled', 'unpaid'
               logger.warn "Subscription for #{team} is #{subscription.status}, downgrading."
               team.inform! "Your subscription to #{subscription.plan.name} (#{ActiveSupport::NumberHelper.number_to_currency(subscription.plan.amount.to_f / 100)}) was canceled and your team has been downgraded. Thank you for being a customer!"
-              team.update_attributes!(subscribed: false)
+              team.update_attributes!(subscribed: false, past_due_informed_at: nil)
             end
           end
         end

--- a/lib/models/team.rb
+++ b/lib/models/team.rb
@@ -3,6 +3,7 @@
 class Team
   field :dead_at, type: DateTime
   field :trial_informed_at, type: DateTime
+  field :past_due_informed_at, type: DateTime
 
   field :stripe_customer_id, type: String
   field :subscribed, type: Boolean, default: false

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -59,14 +59,33 @@ describe SlackGamebot::App do
         expect(Stripe::Customer).to receive(:retrieve).and_return(customer)
         expect_any_instance_of(Team).to receive(:inform!).with("Your subscription to Plan ($49.99) is past due. #{team.update_cc_text}")
         subject.send(:check_subscribed_teams!)
+        expect(team.reload.past_due_informed_at).not_to be_nil
+      end
+
+      it 'does not re-notify past due subscription within 72 hours' do
+        team.update_attributes!(past_due_informed_at: 1.hour.ago)
+        customer.subscriptions.data.first['status'] = 'past_due'
+        expect(Stripe::Customer).to receive(:retrieve).and_return(customer)
+        expect_any_instance_of(Team).not_to receive(:inform!)
+        subject.send(:check_subscribed_teams!)
+      end
+
+      it 'notifies past due subscription again after 72 hours' do
+        team.update_attributes!(past_due_informed_at: 73.hours.ago)
+        customer.subscriptions.data.first['status'] = 'past_due'
+        expect(Stripe::Customer).to receive(:retrieve).and_return(customer)
+        expect_any_instance_of(Team).to receive(:inform!).with("Your subscription to Plan ($49.99) is past due. #{team.update_cc_text}")
+        subject.send(:check_subscribed_teams!)
       end
 
       it 'notifies canceled subscription' do
         customer.subscriptions.data.first['status'] = 'canceled'
+        team.update_attributes!(past_due_informed_at: 1.hour.ago)
         expect(Stripe::Customer).to receive(:retrieve).and_return(customer)
         expect_any_instance_of(Team).to receive(:inform!).with('Your subscription to Plan ($49.99) was canceled and your team has been downgraded. Thank you for being a customer!')
         subject.send(:check_subscribed_teams!)
         expect(team.reload.subscribed?).to be false
+        expect(team.reload.past_due_informed_at).to be_nil
       end
 
       it 'notifies no active subscriptions' do


### PR DESCRIPTION
Fixes #31

Adds a `past_due_informed_at` field to `Team`. When a subscription is `past_due`, the notification is only sent if no notification has been sent in the past 72 hours. The field is cleared when the subscription is canceled/downgraded.
