### PR TITLE
Replace never-called after_start with prepare/cron using Service.instance.once_and_every

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Change Log
 
+* 2026/05/03: Replace never-called `after_start!` with `prepare!`/`cron!` using `Service.instance.once_and_every` - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/05/03: [#70](https://github.com/dblock/slack-gamebot2/issues/70): Proposed challenges auto-expire after 8 hours (minimum 15 minutes); configurable per channel with `set expire <duration|never>` and `unset expire`, supports natural language durations (e.g. `30 minutes`, `2 hours`) - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/05/03: Throttle past due subscription notifications to at most once every 72 hours - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/05/03: Return an error when a player tries to register someone else - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).

--- a/lib/app.rb
+++ b/lib/app.rb
@@ -7,29 +7,27 @@ module SlackGamebot
       Re-install the bot at https://gamebot2.playplay.io. Your data will be purged in 2 weeks.
     EOS
 
-    def after_start!
-      once_and_every 60 * 60 * 24 do
-        check_trials!
-        deactivate_dead_teams!
-        inform_dead_teams!
-        check_subscribed_teams!
-        check_active_subscriptions_without_teams!
-      end
-      once_and_every 15 * 60 do
-        expire_challenges!
+    def prepare!
+      super
+      cron!
+    end
+
+    def cron!
+      SlackRubyBotServer::Service.instance.tap do |instance|
+        instance.once_and_every 60 * 60 * 24 do
+          check_trials!
+          deactivate_dead_teams!
+          inform_dead_teams!
+          check_subscribed_teams!
+          check_active_subscriptions_without_teams!
+        end
+        instance.once_and_every 15 * 60 do
+          expire_challenges!
+        end
       end
     end
 
     private
-
-    def once_and_every(tt)
-      ::Async::Reactor.run do |task|
-        loop do
-          yield
-          task.sleep tt
-        end
-      end
-    end
 
     def expire_challenges!
       channel_ids = Challenge.proposed.distinct(:channel_id)


### PR DESCRIPTION
Fixes a regression introduced in d8f4858 when the app was migrated to OAuth v2/Events API. The old config.ru explicitly called after_start in a thread, but the new one only calls prepare and Service.start -- so after_start was never invoked.

This follows the same pattern used in slack-sup2 (dblock/slack-sup2@4015878): override prepare (calling super) and register intervals via Service.instance.once_and_every, which Service.start picks up through start_intervals.