### PR TITLE
Fix: don't allow recording results for proposed (unaccepted) challenges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Change Log
 
+* 2026/05/03: [#64](https://github.com/dblock/slack-gamebot2/issues/64): Fixed a bug where `lost`, `won`, `draw`, and `resigned` could act on a proposed (not yet accepted) challenge - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/05/03: [#67](https://github.com/dblock/slack-gamebot2/issues/67): Aggregate matches between the same players in `matches` command - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 : Send a reminder for accepted challenges that were never recorded, configurable with `set remind <duration|never>` and `unset remind`, default is 4 hours - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/05/03: Replace never-called `after_start!` with `prepare!`/`cron!` using `Service.instance.once_and_every` - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).

--- a/lib/commands/draw.rb
+++ b/lib/commands/draw.rb
@@ -38,7 +38,6 @@ module SlackGamebot
 
         challenge = ::Challenge.find_by_user(challenger,
                                              [
-                                               ChallengeState::PROPOSED,
                                                ChallengeState::ACCEPTED,
                                                ChallengeState::DRAWN
                                              ])

--- a/lib/commands/lost.rb
+++ b/lib/commands/lost.rb
@@ -36,7 +36,7 @@ module SlackGamebot
           end
         end
 
-        challenge = ::Challenge.find_by_user(challenger, [ChallengeState::PROPOSED, ChallengeState::ACCEPTED])
+        challenge = ::Challenge.find_by_user(challenger, [ChallengeState::ACCEPTED])
 
         if !(teammates & opponents).empty?
           channel.slack_client.say(channel: data.channel, text: 'You cannot lose to yourself!', gif: 'loser')

--- a/lib/commands/resigned.rb
+++ b/lib/commands/resigned.rb
@@ -36,7 +36,7 @@ module SlackGamebot
           end
         end
 
-        challenge = ::Challenge.find_by_user(challenger, [ChallengeState::PROPOSED, ChallengeState::ACCEPTED])
+        challenge = ::Challenge.find_by_user(challenger, [ChallengeState::ACCEPTED])
 
         if scores&.any?
           channel.slack_client.say(channel: data.channel, text: 'Cannot score when resigning.', gif: 'idiot')

--- a/lib/commands/won.rb
+++ b/lib/commands/won.rb
@@ -38,7 +38,7 @@ module SlackGamebot
           end
         end
 
-        challenge = ::Challenge.find_by_user(winner, [ChallengeState::PROPOSED, ChallengeState::ACCEPTED])
+        challenge = ::Challenge.find_by_user(winner, [ChallengeState::ACCEPTED])
 
         if !(teammates & opponents).empty?
           channel.slack_client.say(channel: data.channel, text: 'You cannot win against yourself!', gif: 'winner')

--- a/spec/commands/draw_spec.rb
+++ b/spec/commands/draw_spec.rb
@@ -195,4 +195,17 @@ describe SlackGamebot::Commands::Draw do
       end
     end
   end
+
+  context 'with a proposed challenge' do
+    let(:challenged) { Fabricate(:user, user_name: 'username', channel: channel) }
+    let!(:challenge) { Fabricate(:challenge, challenged: [challenged], channel: channel) }
+
+    it 'cannot draw a challenge that has not been accepted' do
+      expect(message: '@gamebot draw', user: challenged.user_id, channel: challenge.channel).to respond_with_slack_message(
+        'No challenge to draw!'
+      )
+      expect(challenge.reload.state).to eq ChallengeState::PROPOSED
+      expect(Match.count).to eq 0
+    end
+  end
 end

--- a/spec/commands/lost_spec.rb
+++ b/spec/commands/lost_spec.rb
@@ -238,4 +238,17 @@ describe SlackGamebot::Commands::Lost do
       expect(match.resigned?).to be false
     end
   end
+
+  context 'with a proposed challenge' do
+    let(:challenged) { Fabricate(:user, channel: channel, user_name: 'username') }
+    let!(:challenge) { Fabricate(:challenge, channel: channel, challenged: [challenged]) }
+
+    it 'cannot lose a challenge that has not been accepted' do
+      expect(message: '@gamebot lost', user: challenged.user_id, channel: challenge.channel).to respond_with_slack_message(
+        'No challenge to lose!'
+      )
+      expect(challenge.reload.state).to eq ChallengeState::PROPOSED
+      expect(Match.count).to eq 0
+    end
+  end
 end

--- a/spec/commands/resigned_spec.rb
+++ b/spec/commands/resigned_spec.rb
@@ -83,4 +83,17 @@ describe SlackGamebot::Commands::Resigned do
       expect(match.resigned?).to be true
     end
   end
+
+  context 'with a proposed challenge' do
+    let(:challenged) { Fabricate(:user, channel: channel, user_name: 'username') }
+    let!(:challenge) { Fabricate(:challenge, channel: channel, challenged: [challenged]) }
+
+    it 'cannot resign a challenge that has not been accepted' do
+      expect(message: '@gamebot resigned', user: challenged.user_id, channel: challenge.channel).to respond_with_slack_message(
+        'No challenge to resign!'
+      )
+      expect(challenge.reload.state).to eq ChallengeState::PROPOSED
+      expect(Match.count).to eq 0
+    end
+  end
 end

--- a/spec/commands/won_spec.rb
+++ b/spec/commands/won_spec.rb
@@ -199,4 +199,18 @@ describe SlackGamebot::Commands::Won do
       )
     end
   end
+
+  context 'with a proposed challenge' do
+    let(:challenger) { Fabricate(:user, channel: channel) }
+    let(:challenged_user) { Fabricate(:user, channel: channel, user_name: 'username') }
+    let!(:challenge) { Fabricate(:challenge, channel: channel, challengers: [challenger], challenged: [challenged_user]) }
+
+    it 'cannot win a challenge that has not been accepted' do
+      expect(message: '@gamebot won', user: challenger.user_id, channel: challenge.channel).to respond_with_slack_message(
+        'No challenge to win!'
+      )
+      expect(challenge.reload.state).to eq ChallengeState::PROPOSED
+      expect(Match.count).to eq 0
+    end
+  end
 end


### PR DESCRIPTION
Fixes #64.

## Problem

## Fix
- Changed `find_by_user` calls in `lost.rb`, `won.rb`, `resigned.rb`, and `draw.rb` to only search `ACCEPTED` state (draw also keeps `DRAWN`).
- Added regression tests for each command verifying that a proposed challenge is not acted upon.