### PR TITLE
Support humiliation when the loser scores zero points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Change Log
 
+* 2026/05/03: [#62](https://github.com/dblock/slack-gamebot2/issues/62): Display "humiliated" when the loser scores zero points (shutout) - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/05/03: [#65](https://github.com/dblock/slack-gamebot2/issues/65): Added `games` command to show how many games each player has played - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/05/03: [#67](https://github.com/dblock/slack-gamebot2/issues/67): Aggregate matches between the same players in `matches` command - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 : Send a reminder for accepted challenges that were never recorded, configurable with `set remind <duration|never>` and `unset remind`, default is 4 hours - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).

--- a/README.md
+++ b/README.md
@@ -106,12 +106,18 @@ Record your loss.
 
 ![](screenshots/lost.gif)
 
-Record your loss with a score, loser first.
+Record your loss with a score, loser first. The result verb depends on how lopsided the score is: _narrowly defeated_, _defeated_, _crushed_, or _humiliated_ (shutout).
 
 ```
 gamebot lost 5:21
 
 Match has been recorded! Wang Hoe crushed Victor Barna with the score of 21:5.
+```
+
+```
+gamebot lost 0:21
+
+Match has been recorded! Wang Hoe humiliated Victor Barna with the score of 21:0.
 ```
 
 You can record scores for an entire match.

--- a/lib/models/match.rb
+++ b/lib/models/match.rb
@@ -164,8 +164,10 @@ class Match
         'narrowly defeated'
       elsif ratio > 0.4
         'defeated'
-      else
+      elsif ratio.positive?
         'crushed'
+      else
+        'humiliated'
       end
     end
   end

--- a/spec/commands/lost_spec.rb
+++ b/spec/commands/lost_spec.rb
@@ -86,6 +86,12 @@ describe SlackGamebot::Commands::Lost do
       )
     end
 
+    it 'lost with a humiliating score' do
+      expect(message: '@gamebot lost 0:21', user: challenged.user_id, channel: challenge.channel).to respond_with_slack_message(
+        "Match has been recorded! #{challenge.challengers[0].display_name} (+96) humiliated #{challenge.challenged[0].display_name} (-96) with the score of 21:0."
+      )
+    end
+
     it 'lost in a close game' do
       expect(message: '@gamebot lost 19:21', user: challenged.user_id, channel: challenge.channel).to respond_with_slack_message(
         "Match has been recorded! #{challenge.challengers[0].display_name} (+50) narrowly defeated #{challenge.challenged[0].display_name} (-50) with the score of 21:19."

--- a/spec/commands/won_spec.rb
+++ b/spec/commands/won_spec.rb
@@ -79,6 +79,12 @@ describe SlackGamebot::Commands::Won do
       )
     end
 
+    it 'won with a humiliating score' do
+      expect(message: '@gamebot won 21:0', user: challenger.user_id, channel: challenge.channel).to respond_with_slack_message(
+        "Match has been recorded! #{challenger.display_name} (+96) humiliated #{challenged_user.display_name} (-96) with the score of 21:0."
+      )
+    end
+
     it 'won in a close game' do
       expect(message: '@gamebot won 21:19', user: challenger.user_id, channel: challenge.channel).to respond_with_slack_message(
         "Match has been recorded! #{challenger.display_name} (+50) narrowly defeated #{challenged_user.display_name} (-50) with the score of 21:19."


### PR DESCRIPTION
Closes #62.

When a player is shut out (scores zero points), the match message now reads "X humiliated Y" instead of "X crushed Y".

Score verb scale:
- ratio > 0.9 → "narrowly defeated"
- ratio > 0.4 → "defeated"  
- ratio > 0 → "crushed"
- ratio == 0 (shutout) → "humiliated"