### PR TITLE
Prevent unregistered users from challenge/accept/cancel/decline/lost/won/draw/resigned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Change Log
 
+* 2026/05/03: [#26](https://github.com/dblock/slack-gamebot2/issues/26): Unregistered users can no longer challenge, accept, cancel, decline, lost, won, draw, or resign - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/05/03: [#25](https://github.com/dblock/slack-gamebot2/issues/25): Added `undo` command to undo the last match recorded within the last hour - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/05/03: [#47](https://github.com/dblock/slack-gamebot2/issues/47): Added `predict` command to show win probability based on Elo ratings - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/05/03: [#57](https://github.com/dblock/slack-gamebot2/issues/57): Limit simultaneous accepted challenges with `set max challenges [number]` and `unset max challenges`, no limit by default - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).

--- a/lib/commands/accept.rb
+++ b/lib/commands/accept.rb
@@ -6,6 +6,8 @@ module SlackGamebot
       include SlackGamebot::Commands::Mixins::User
 
       user_in_channel_command 'accept' do |channel, user, data|
+        raise SlackGamebot::Error, "You're not registered. Type _register_ to register." unless user.registered?
+
         challenge = ::Challenge.find_by_user(user)
         challenge ||= ::Challenge.find_open_challenge(channel)
 

--- a/lib/commands/cancel.rb
+++ b/lib/commands/cancel.rb
@@ -6,6 +6,8 @@ module SlackGamebot
       include SlackGamebot::Commands::Mixins::User
 
       user_in_channel_command 'cancel' do |channel, player, data|
+        raise SlackGamebot::Error, "You're not registered. Type _register_ to register." unless player.registered?
+
         challenge = ::Challenge.find_by_user(player)
         if challenge
           challenge.cancel!(player)

--- a/lib/commands/challenge.rb
+++ b/lib/commands/challenge.rb
@@ -6,6 +6,8 @@ module SlackGamebot
       include SlackGamebot::Commands::Mixins::User
 
       user_in_channel_command 'challenge' do |channel, challenger, data|
+        raise SlackGamebot::Error, "You're not registered. Type _register_ to register." unless challenger.registered?
+
         arguments = data.match['expression'].split.reject(&:blank?) if data.match['expression']
         challenge = ::Challenge.create_from_teammates_and_opponents!(challenger, arguments || [])
         channel.slack_client.say(channel: data.channel, text: "#{challenge.challengers.map(&:slack_mention).and} challenged #{challenge.challenged.map(&:slack_mention).and} to a match!", gif: 'challenge')

--- a/lib/commands/decline.rb
+++ b/lib/commands/decline.rb
@@ -6,6 +6,8 @@ module SlackGamebot
       include SlackGamebot::Commands::Mixins::User
 
       user_in_channel_command 'decline' do |channel, challenger, data|
+        raise SlackGamebot::Error, "You're not registered. Type _register_ to register." unless challenger.registered?
+
         challenge = ::Challenge.find_by_user(challenger)
         if challenge
           challenge.decline!(challenger)

--- a/lib/commands/draw.rb
+++ b/lib/commands/draw.rb
@@ -6,6 +6,8 @@ module SlackGamebot
       include SlackGamebot::Commands::Mixins::User
 
       user_in_channel_command 'draw' do |channel, challenger, data|
+        raise SlackGamebot::Error, "You're not registered. Type _register_ to register." unless challenger.registered?
+
         expression = data.match['expression'] if data.match['expression']
         arguments = expression.split.reject(&:blank?) if expression
 

--- a/lib/commands/lost.rb
+++ b/lib/commands/lost.rb
@@ -6,6 +6,8 @@ module SlackGamebot
       include SlackGamebot::Commands::Mixins::User
 
       user_in_channel_command 'lost' do |channel, challenger, data|
+        raise SlackGamebot::Error, "You're not registered. Type _register_ to register." unless challenger.registered?
+
         expression = data.match['expression'] if data.match['expression']
         arguments = expression.split.reject(&:blank?) if expression
 

--- a/lib/commands/resigned.rb
+++ b/lib/commands/resigned.rb
@@ -6,6 +6,8 @@ module SlackGamebot
       include SlackGamebot::Commands::Mixins::User
 
       user_in_channel_command 'resigned' do |channel, challenger, data|
+        raise SlackGamebot::Error, "You're not registered. Type _register_ to register." unless challenger.registered?
+
         expression = data.match['expression'] if data.match['expression']
         arguments = expression.split.reject(&:blank?) if expression
 

--- a/lib/commands/won.rb
+++ b/lib/commands/won.rb
@@ -6,6 +6,7 @@ module SlackGamebot
       include SlackGamebot::Commands::Mixins::User
 
       user_in_channel_command 'won' do |channel, winner, data|
+        raise SlackGamebot::Error, "You're not registered. Type _register_ to register." unless winner.registered?
         raise SlackGamebot::Error, "The won command is disabled for #{channel.slack_mention}." unless channel.won?
 
         expression = data.match['expression'] if data.match['expression']

--- a/spec/commands/accept_spec.rb
+++ b/spec/commands/accept_spec.rb
@@ -63,4 +63,16 @@ describe SlackGamebot::Commands::Accept do
       expect(challenge.reload.state).to eq ChallengeState::PROPOSED
     end
   end
+
+  context 'unregistered user' do
+    let(:user) { Fabricate(:user, channel: channel) }
+
+    before { user.unregister! }
+
+    it 'cannot accept' do
+      expect(message: '@gamebot accept', user: user.user_id, channel: channel).to respond_with_slack_message(
+        "You're not registered. Type _register_ to register."
+      )
+    end
+  end
 end

--- a/spec/commands/cancel_spec.rb
+++ b/spec/commands/cancel_spec.rb
@@ -28,4 +28,16 @@ describe SlackGamebot::Commands::Cancel do
       expect(challenge.reload.state).to eq ChallengeState::CANCELED
     end
   end
+
+  context 'unregistered user' do
+    let(:user) { Fabricate(:user, channel: channel) }
+
+    before { user.unregister! }
+
+    it 'cannot cancel' do
+      expect(message: '@gamebot cancel', user: user.user_id, channel: channel).to respond_with_slack_message(
+        "You're not registered. Type _register_ to register."
+      )
+    end
+  end
 end

--- a/spec/commands/challenge_spec.rb
+++ b/spec/commands/challenge_spec.rb
@@ -96,6 +96,18 @@ describe SlackGamebot::Commands::Challenge do
     )
   end
 
+  context 'requires the challenger to be registered' do
+    before do
+      user.unregister!
+    end
+
+    it 'cannot challenge when unregistered' do
+      expect(message: "@gamebot challenge #{opponent.slack_mention}", user: user.user_id, channel: channel).to respond_with_slack_message(
+        "You're not registered. Type _register_ to register."
+      )
+    end
+  end
+
   context 'requires the opponent to be registered' do
     before do
       opponent.unregister!

--- a/spec/commands/decline_spec.rb
+++ b/spec/commands/decline_spec.rb
@@ -14,4 +14,14 @@ describe SlackGamebot::Commands::Decline do
     )
     expect(challenge.reload.state).to eq ChallengeState::DECLINED
   end
+
+  context 'unregistered user' do
+    before { challenged.unregister! }
+
+    it 'cannot decline' do
+      expect(message: '@gamebot decline', user: challenged.user_id, channel: challenge.channel).to respond_with_slack_message(
+        "You're not registered. Type _register_ to register."
+      )
+    end
+  end
 end

--- a/spec/commands/draw_spec.rb
+++ b/spec/commands/draw_spec.rb
@@ -195,4 +195,16 @@ describe SlackGamebot::Commands::Draw do
       end
     end
   end
+
+  context 'unregistered user' do
+    let(:user) { Fabricate(:user, channel: channel) }
+
+    before { user.unregister! }
+
+    it 'cannot record a draw' do
+      expect(message: '@gamebot draw', user: user.user_id, channel: channel).to respond_with_slack_message(
+        "You're not registered. Type _register_ to register."
+      )
+    end
+  end
 end

--- a/spec/commands/lost_spec.rb
+++ b/spec/commands/lost_spec.rb
@@ -244,4 +244,16 @@ describe SlackGamebot::Commands::Lost do
       expect(match.resigned?).to be false
     end
   end
+
+  context 'unregistered user' do
+    let(:loser) { Fabricate(:user, channel: channel) }
+
+    before { loser.unregister! }
+
+    it 'cannot record a loss' do
+      expect(message: '@gamebot lost', user: loser.user_id, channel: channel).to respond_with_slack_message(
+        "You're not registered. Type _register_ to register."
+      )
+    end
+  end
 end

--- a/spec/commands/resigned_spec.rb
+++ b/spec/commands/resigned_spec.rb
@@ -83,4 +83,16 @@ describe SlackGamebot::Commands::Resigned do
       expect(match.resigned?).to be true
     end
   end
+
+  context 'unregistered user' do
+    let(:user) { Fabricate(:user, channel: channel) }
+
+    before { user.unregister! }
+
+    it 'cannot resign' do
+      expect(message: '@gamebot resigned', user: user.user_id, channel: channel).to respond_with_slack_message(
+        "You're not registered. Type _register_ to register."
+      )
+    end
+  end
 end

--- a/spec/commands/won_spec.rb
+++ b/spec/commands/won_spec.rb
@@ -205,4 +205,16 @@ describe SlackGamebot::Commands::Won do
       )
     end
   end
+
+  context 'unregistered user' do
+    let(:user) { Fabricate(:user, channel: channel) }
+
+    before { user.unregister! }
+
+    it 'cannot record a win' do
+      expect(message: '@gamebot won', user: user.user_id, channel: channel).to respond_with_slack_message(
+        "You're not registered. Type _register_ to register."
+      )
+    end
+  end
 end


### PR DESCRIPTION
Fixes #26.

An unregistered user could still issue challenges and record match results, effectively re-registering themselves through side effects.

## Changes

Added a registration guard at the top of each action command:
- `challenge` - cannot challenge when unregistered
- `accept` - cannot accept a challenge when unregistered
- `cancel` - cannot cancel a challenge when unregistered
- `decline` - cannot decline a challenge when unregistered
- `lost` - cannot record a loss when unregistered
- `won` - cannot record a win when unregistered
- `draw` - cannot record a draw when unregistered
- `resigned` - cannot resign when unregistered

All respond with: _"You're not registered. Type register to register."_

## Tests

Added one unregistered-user spec per command (8 new examples, 87 total passing).