### PR TITLE
Limit lost/won score updates to matches within the last hour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Change Log
 
+* 2026/05/03: [#66](https://github.com/dblock/slack-gamebot2/issues/66): Score updates via `lost`/`won`/`draw` without opponents now only apply to matches within the last hour - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/05/03: [#26](https://github.com/dblock/slack-gamebot2/issues/26): Unregistered users can no longer challenge, accept, cancel, decline, lost, won, draw, or resign - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/05/03: [#25](https://github.com/dblock/slack-gamebot2/issues/25): Added `undo` command to undo the last match recorded within the last hour - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/05/03: [#47](https://github.com/dblock/slack-gamebot2/issues/47): Added `predict` command to show win probability based on Elo ratings - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).

--- a/lib/commands/draw.rb
+++ b/lib/commands/draw.rb
@@ -89,7 +89,7 @@ module SlackGamebot
           end
           logger.info "DRAW: #{channel} - #{challenge}"
         else
-          match = ::Match.any_of({ winner_ids: challenger.id }, loser_ids: challenger.id).desc(:id).first
+          match = ::Match.current.any_of({ winner_ids: challenger.id }, loser_ids: challenger.id).where(:created_at.gte => 1.hour.ago).desc(:id).first
           if match&.tied?
             match.update_attributes!(scores: scores)
             channel.slack_client.say(channel: data.channel, text: "Match scores have been updated! #{match}.", gif: 'score')

--- a/lib/commands/lost.rb
+++ b/lib/commands/lost.rb
@@ -54,7 +54,7 @@ module SlackGamebot
           channel.slack_client.chat_postMessage(channel: data.channel, text: channel.leaderboard_s, thread_ts: rc['ts']) if rc.key?('ts') && channel.details.include?(Details::LEADERBOARD)
           logger.info "LOST: #{channel} - #{challenge}"
         else
-          match = ::Match.where(loser_ids: challenger.id).desc(:_id).first
+          match = ::Match.current.where(loser_ids: challenger.id, :created_at.gte => 1.hour.ago).desc(:_id).first
           if match
             match.update_attributes!(scores: scores)
             channel.slack_client.say(channel: data.channel, text: "Match scores have been updated! #{match}.", gif: 'score')

--- a/lib/commands/won.rb
+++ b/lib/commands/won.rb
@@ -55,7 +55,7 @@ module SlackGamebot
           channel.slack_client.chat_postMessage(channel: data.channel, text: channel.leaderboard_s, thread_ts: rc['ts']) if rc.key?('ts') && channel.details.include?(Details::LEADERBOARD)
           logger.info "WON: #{channel} - #{challenge}"
         else
-          match = ::Match.where(winner_ids: winner.id).desc(:_id).first
+          match = ::Match.current.where(winner_ids: winner.id, :created_at.gte => 1.hour.ago).desc(:_id).first
           if match
             match.update_attributes!(scores: scores)
             channel.slack_client.say(channel: data.channel, text: "Match scores have been updated! #{match}.", gif: 'score')

--- a/spec/commands/draw_spec.rb
+++ b/spec/commands/draw_spec.rb
@@ -196,6 +196,26 @@ describe SlackGamebot::Commands::Draw do
     end
   end
 
+  context 'amending scores on a tied match' do
+    let(:player) { Fabricate(:user, channel: channel, user_name: 'username') }
+    let(:opponent) { Fabricate(:user, channel: channel) }
+    let!(:match) { Fabricate(:match, channel: channel, winners: [player], losers: [opponent], tied: true) }
+
+    it 'updates scores of a recent tied match' do
+      expect(message: '@gamebot draw 3:3', user: player.user_id, channel: channel).to respond_with_slack_message(
+        "Match scores have been updated! #{match}."
+      )
+      expect(match.reload.scores).to eq [[3, 3]]
+    end
+
+    it 'cannot amend scores of a tied match older than 1 hour' do
+      match.update_attributes!(created_at: 2.hours.ago)
+      expect(message: '@gamebot draw 3:3', user: player.user_id, channel: channel).to respond_with_slack_message(
+        'No challenge to draw!'
+      )
+    end
+  end
+
   context 'unregistered user' do
     let(:user) { Fabricate(:user, channel: channel) }
 

--- a/spec/commands/lost_spec.rb
+++ b/spec/commands/lost_spec.rb
@@ -107,6 +107,14 @@ describe SlackGamebot::Commands::Lost do
       expect(challenge.match.scores).to eq [[21, 15], [14, 21], [5, 11]]
     end
 
+    it 'cannot amend scores of a match older than 1 hour' do
+      challenge.lose!(challenged)
+      challenge.match.update_attributes!(created_at: 2.hours.ago)
+      expect(message: '@gamebot lost 21:15 14:21 5:11', user: challenged.user_id, channel: challenge.channel).to respond_with_slack_message(
+        'No challenge to lose!'
+      )
+    end
+
     it 'does not update a previously lost match' do
       challenge.lose!(challenged, [[11, 21]])
       challenge2 = Fabricate(:challenge, challenged: [challenged])

--- a/spec/commands/won_spec.rb
+++ b/spec/commands/won_spec.rb
@@ -100,6 +100,14 @@ describe SlackGamebot::Commands::Won do
       expect(challenge.match.scores).to eq [[15, 21], [21, 14], [5, 11]]
     end
 
+    it 'cannot amend scores of a match older than 1 hour' do
+      challenge.win!(challenger)
+      challenge.match.update_attributes!(created_at: 2.hours.ago)
+      expect(message: '@gamebot won 21:15 14:21 11:5', user: challenger.user_id, channel: challenge.channel).to respond_with_slack_message(
+        'No challenge to win!'
+      )
+    end
+
     it 'cannot win against yourself' do
       expect(message: "@gamebot won against #{challenger.user_name}", user: challenger.user_id, channel: challenge.channel).to respond_with_slack_message(
         'You cannot win against yourself!'


### PR DESCRIPTION
Fixes #66.

When `lost`, `won`, or `draw` is called without opponents and no open challenge exists, it falls back to updating scores on the user's most recent match. Previously this would find **any** historical match — including old archived ones — silently updating scores from a completely different context.

## Fix

All three fallback queries now require:
- `Match.current` — current season only (no archived matches)
- `created_at >= 1.hour.ago` — within the last hour

This mirrors the same guard used by the `undo` command.

## Tests

Added one spec per command verifying that a match older than 1 hour cannot have its scores amended via the fallback path.